### PR TITLE
Invoke value was passing the context as the extraArgs

### DIFF
--- a/heroin.js
+++ b/heroin.js
@@ -56,7 +56,7 @@
       return new Injector(me, extraArgs).instantiate(ctor);
     };
     this.values.invoke = function(func, extraArgs) {
-      return me.invoke(func, extraArgs);
+      return me.invoke(func, func, extraArgs);
     };
     this.make = this.values.make;
     this.make.__proto__ = this;


### PR DESCRIPTION
Was trying to resolve arguments from a function (not a class) -- pretty sure that the invoke thats a value in the Injector function, was passing the extraArgs parameter as the context to the Injector.prototype.invoke (rather than the self.context).

D.
